### PR TITLE
Adding `id` option to shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The Table Importer shortcode is a self-closing `[ti option1="value1" option2="va
 
 * `class` lets you assign class definitions to the table itself. Whatever you put here will be escaped (via PHP's `htmlspecialchars`) and placed into the opening `<table>` tag.
 
+* `id` lets you specify the table tag's `id` attribute (e.g. `[ti file="mytable.yaml" id="my-custom-table-id"]` yields `<table id="my-custom-table-id">...</table>`).
+
 * By default, the content of each cell is escaped using PHP's `htmlspecialchars` function. If the `raw` option is set to anything at all, the escaping will be disabled. **Only do this if you trust the incoming data!**
 
 * Finally, for CSV files only, you can customize how it will be parsed using any of the following three options:

--- a/TableImporterShortcode.php
+++ b/TableImporterShortcode.php
@@ -110,7 +110,12 @@ class TableImporterShortcode extends Shortcode
             return "<p>Table Importer: Something went wrong loading '$type' data from the requested file '$fn'.</p>";
         }
         $output = '';
-        $id = $this->shortcode->getId($sc);
+        
+        // Table's id can be specified by adding an `id` attribute to the shortcode
+        $id = $sc->getParameter('id', null);
+        if ($id === null)
+          $id = $this->shortcode->getId($sc);
+        
         $output .= '<table id="'.$id.'"';
         if ($class !== null) {
             $output .= ' class="'.htmlspecialchars($class).'"';


### PR DESCRIPTION
Now you can specify the `id` attribute of the table tag via the Table Importer shortcode (e.g. `[ti id="my-custom-id"]` yields `<table id="my-custom-id">...</table>`).